### PR TITLE
Avoid emitting unnecessary spelling suggestions

### DIFF
--- a/src/mockgyver.erl
+++ b/src/mockgyver.erl
@@ -694,10 +694,14 @@ fmt_waiter_calls(#call_waiter{mfa={WaitM,WaitF,WaitA0}, loc={File,Line}}=Waiter,
     lists:flatten(
       [f("~s:~p:~n    Waiter: ~p:~p/~p~n~n", [File, Line, WaitM, WaitF, WaitA]),
        case CandMFAs of
-           [] -> f("    Unfortunately there are no similar functions~n", []);
-           _  -> f("    Did you intend to verify one of these functions?~n"
-                   "~s~n",
-                   [fmt_candidate_mfas(CandMFAs, _Indent=8)])
+           [] ->
+               f("    Unfortunately there are no similar functions~n", []);
+           [{WaitM, WaitF, WaitA}] ->
+               "";
+           _ ->
+               f("    Did you intend to verify one of these functions?~n"
+                 "~s~n",
+                 [fmt_candidate_mfas(CandMFAs, _Indent=8)])
        end,
        case CallMFAs of
            [] -> f("    Unfortunately there are no registered calls~n", []);


### PR DESCRIPTION
For a ?WAS_CALLED(...), that didn't match any registered calls,
mockgyver helpfully tries to find misspellings, but when the
function call was not misspelled, and was the only candidate,
the helpful text in fact looked confusing:
```
    Test died while waiting for a call.

    /tmp/xyz.erl:488:
        Waiter: abc:def/3

        Did you intend to verify one of these functions?
                abc:def/3

        Unfortunately there are no registered calls
```


This commit removes the "Did you intend..." text when it is the
only (correctly spelled) matching candidate, and the output for this
case now looks like this:
```
    Test died while waiting for a call.

    /tmp/xyz.erl:488:
        Waiter: abc:def/3

        Unfortunately there are no registered calls
```