### PR TITLE
Avoid warnings about matching of underscored vars

### DIFF
--- a/src/mockgyver.erl
+++ b/src/mockgyver.erl
@@ -693,13 +693,13 @@ fmt_waiter_calls(#call_waiter{mfa={WaitM,WaitF,WaitA0}, loc={File,Line}}=Waiter,
            _ ->
                f("    Did you intend to verify one of these functions?~n"
                  "~s~n",
-                 [fmt_candidate_mfas(CandMFAs, _Indent=8)])
+                 [fmt_candidate_mfas(CandMFAs, 8)])
        end,
        case CallMFAs of
            [] -> f("    Unfortunately there are no registered calls~n", []);
            _  -> f("    Registered calls in order of decreasing similarity:~n"
                    "~s~n",
-                   [fmt_calls(CallMFAs, _Indent=8)])
+                   [fmt_calls(CallMFAs, 8)])
        end,
        f("~n", [])]).
 


### PR DESCRIPTION
In Erlang 24, there is a warning when matching a variable name if it begins with an underscore:
```
src/mockgyver.erl:696:48: Warning: variable '_Indent' is bound multiple times in this pattern. If you mean to ignore this value, use '_' or a different underscore-prefixed name
%  696|                  [fmt_candidate_mfas(CandMFAs, _Indent=8)])
%     |                                                ^

src/mockgyver.erl:702:41: Warning: variable '_Indent' is bound multiple times in this pattern. If you mean to ignore this value, use '_' or a different underscore-prefixed name
%  702|                    [fmt_calls(CallMFAs, _Indent=8)])
%     |                                         ^
```