### PR TITLE
Drop FUNCTION_NAME definition in tests

### DIFF
--- a/test/mockgyver_tests.erl
+++ b/test/mockgyver_tests.erl
@@ -37,13 +37,6 @@
 -include_lib("stdlib/include/ms_transform.hrl").
 -include("../include/mockgyver.hrl").
 
-%% This macro was introduced in Erlang/OTP 19.0.
-%% This is a workaround for older releases.
--ifndef(FUNCTION_NAME).
--define(FUNCTION_NAME,
-        element(2, element(2, process_info(self(), current_function)))).
--endif.
-
 -record('DOWN', {mref, type, obj, info}).
 
 -define(recv(PatternAction), ?recv(PatternAction, 4000)).


### PR DESCRIPTION
Remove a compatibility definition (if-needed) of FUNCTION_NAME
to avoid the error below.
```
  mockgyver_tests.erl:43:9: redefining predefined macro 'FUNCTION_NAME'
  %   43| -define(FUNCTION_NAME,
  %     |         ^
```
The behaviour changed somewhere between Erlang 24.0 and 24.1.