### PR TITLE
Fix inlined stacktrace

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otpvsn: [21, 22, 23, 24]
+        otpvsn: [22, 23, 24, 25]
 
     container:
       image: erlang:${{ matrix.otpvsn }}


### PR DESCRIPTION
This is the first of two related PRs:
* This one fixes a unit test in Erlang 25 and 26. More details below.
* The next one is #29, which fixes dialyzer issues in Erlang 26.
____

I noticed that the eunit test `includes_mocked_mfa_in_stacktrace_on_function_clause_test/1` fails on 25.2.3 and 26.0 but not on 24.3.4.8. The base for this seems to be that the stacktrace contains for instance `'-f/1-inlined-0-'` whereas the `fun_info(F, name)` would return `'-f/1-fun-0-'`. Due to this difference, the [generated `'$mockgyver_map_st'/4` doesn't find the right thing to replace](https://github.com/klajo/mockgyver/blob/master/src/mockgyver.erl#L1570-L1608)

The simplest program I could come up with to demonstrate the issue is this:
```erlang
-module(x).
-export([h/1, fp1/0]).


h(N) ->
    F = fp1(),
    N = (F)(N).

-compile({inline,[fp1/0]}).
fp1() -> fun(N) when N >= 0 -> N + 1 end.
```

```erlang
# Erlang/OTP 25 [erts-13.1.5] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit:ns]
Eshell V13.1.5  (abort with ^G)
...
85> x:h(-1).
** exception error: no function clause matching x:'-h/1-inlined-0-'(-1) (/tmp/x.erl, line 10)
86> erlang:fun_info(x:fp1(), name).
{name,'-fp1/0-fun-0-'}
```

My attempt is a bit crude and I'm not entirely happy with it in its current form, but putting it forward anyway, to have something to work with for a while. What the PR does is it tries to replace `'-f/1-fun-0-'` and then `'-f/1-inlined-0-'`. It arrives at `'-f/1-inlined-0-'` by doing text substitution, but:
* If replaces the first `-fun-` with `-inlined-`. In theory they could maybe be nested, but in practice, I think they seldom are. Maybe the last `-inlined-` should be replaced instead. That would make the code a bit more complicated though.
* The `-fun-` can sometimes be `-anonymous-` as I've noticed. Don't know if such functions can appear as inlined or not, though.

In the demonstrator above, one of the many possible changes that make `-inlined-` go back to `-fun-` is if I comment-out the `-compile({inline,[fp1/0]}).` line. This makes me think an alternative solution, if it works, could be to just specify `-compile({no_inline, [something]}).` It would be cleaner, I think, but I haven't been digging deep enough to understand if this approach can work, and what to mark, or how or where that might be generated.

~ ~ ~

One more thing: This PR additionally contains a commit that shifts the github workflow to include Erlang 25, dropping 21. I don't remember what the policy regarding old Erlang versions was, so I made a guess and took a chance here. Just let me know if you want 21 still in the game.