### PR TITLE
Fix dialyzer erl26

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otpvsn: [22, 23, 24, 25]
+        otpvsn: [23, 24, 25, 26]
 
     container:
       image: erlang:${{ matrix.otpvsn }}

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otpvsn: [21, 22, 23, 24]
+        otpvsn: [22, 23, 24, 25]
 
     container:
       image: erlang:${{ matrix.otpvsn }}

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,10 @@
 {edoc_opts,
  [{preprocess, true}]}.
 
+{dialyzer, [{warnings, [unknown]},
+            {plt_apps, all_deps},
+            {plt_extra_apps, [syntax_tools, compiler,
+                              parse_trans]}]}.
 {profiles,
  %% Add the edown dependency (for generating markdown docs) when
  %% running with the edown profile ==> make it an optional dependency.

--- a/src/mockgyver_sup.erl
+++ b/src/mockgyver_sup.erl
@@ -59,7 +59,7 @@
 %% Starts the supervisor
 %% @end
 %%--------------------------------------------------------------------
--spec start_link() -> supervisor:start_link_ret().
+-spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 


### PR DESCRIPTION
This is the second of two related PRs:
* The previous one is #28, which fixes a unit test in Erlang 25 and 26.
* This one fixes dialyzer issues in Erlang 26. It currently is on a branch spun out from the #28 PR, but I can rebase if you want, just let me know.
____
Dialyzer in Erlang 26 has changed to warn also warn for references to unknown types. In Erlang 25, this was an option, but now it is the default. This uncovered some type-typos. I had to include some more apps for dialyzer to find all referred-to types, so the actions take a bit longer to run. When one runs locally, rebar3+dialyzer are smart enough to reuse the plt though.

Dialyzer in Erlang 26 also found two left-over calls to `gen_server:reply` from the `gen_statem` rewrite(s). This PR changes them to `gen_statem:reply`. Both calls are actually exercised by the eunit tests.

This PR additionally contains a commit that shifts the github workflow to include Erlang 26, dropping Erlang 22. Again, let me know if you want to keep older version.