### PR TITLE
Migarate github actions to Node 16

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -18,7 +18,7 @@ jobs:
       image: erlang:${{ matrix.otpvsn }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Compile
       run: rebar3 compile
     - name: Dialyze


### PR DESCRIPTION
The warning message in actions is/was (line-wrapped):

  Node.js 12 actions are deprecated. Please update the following
  actions to use Node.js 16: actions/checkout@v2.  For more
  information see:
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

So change from actions/checkout@v2 to v3 which is in the examples that the above page refers to:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions